### PR TITLE
Update setup.php

### DIFF
--- a/setup.php
+++ b/setup.php
@@ -365,7 +365,7 @@ function flowview_setup_table() {
 	global $config;
 
 	$data = array();
-	$data['columns'][]  = array('name' => 'ip', 'type' => 'varchar(32)', 'NULL' => false, 'default' => '');
+	$data['columns'][]  = array('name' => 'ip', 'type' => 'varchar(45)', 'NULL' => false, 'default' => '');
 	$data['columns'][]  = array('name' => 'host', 'type' => 'varchar(255)', 'NULL' => false, 'default' => '');
 	$data['columns'][]  = array('name' => 'time', 'type' => 'bigint(20)', 'unsigned' => true, 'NULL' => false, 'default' => '0');
 	$data['keys'][]     = array('name' => 'ip', 'columns' => 'ip');


### PR DESCRIPTION
table plugin_flowview_dnscache  ip needs to be > as varchar(32) as it is not storing full ipv6 format.
I think later this function needs to be redesigned.

In functions.php 
function flowview_get_dns_from_ip

ipv6 addresses cannot be matched as when they are put into the db they are cut to varchar(32) and next time again and again as such filling the cache DB.