### PR TITLE
fix php error when null is returned

### DIFF
--- a/flowview_devices.php
+++ b/flowview_devices.php
@@ -366,7 +366,9 @@ function show_devices () {
 				$status = shell_exec("netstat -anp | grep ':" . $row['port'] . " '");
 			}
 
-			$parts = preg_split('/[\s]+/', trim($status));
+			if (is_string($status)) {
+				$parts = preg_split('/[\s]+/', trim($status));
+			}
 
 			form_alternate_row('line' . $row['id'], true);
 			form_selectable_cell('<a class="linkEditMain" href="flowview_devices.php?action=edit&id=' . $row['id'] . '">' . $row['name'] . '</a>', $row['id']);


### PR DESCRIPTION
024-05-19 17:38:17 - ERROR PHP DEPRECATED in  Plugin 'flowview': trim(): Passing null to parameter #1 ($string) of type string is 
deprecated in file: /usr/local/share/cacti/plugins/flowview/flowview_devices.php  on line: 369
2024-05-19 17:38:17 - CMDPHP PHP ERROR Backtrace:  (/plugins/flowview/flowview_devices.php[88]:show_devices(), /plugins/flowview/flowview_devices.php[369]:trim(), CactiErrorHandler())
2024-05-19 17:38:17 - AUTH DEBUG: Using remote client