### PR TITLE
fix php warning - undefined array key ..

### DIFF
--- a/setup.php
+++ b/setup.php
@@ -1285,6 +1285,9 @@ function flowview_graph_button($data) {
 				} elseif ($c == 'statistics' && $query_data[$c] > 0) {
 					$url .= "&report=s{$query_data[$c]}";
 				} else {
+					if (!isset($query_data[$c])) {
+						return false;
+					}
 					$url .= "&$c={$query_data[$c]}";
 				}
 			}


### PR DESCRIPTION
A lot of messages when viewing graph for device with flowview .
Warning: Undefined array key "device_id" in /usr/local/share/cacti/plugins/flowview/setup.php on line 1291
Warning: Undefined array key "includeif" in /usr/local/share/cacti/plugins/flowview/setup.php on line 1291
Warning: Undefined array key "sortfield" in /usr/local/share/cacti/plugins/flowview/setup.php on line 1291
Warning: Undefined array key "cutofflines" in /usr/local/share/cacti/plugins/flowview/setup.php on line 1291

My query_data has only:
array(1) { ["ex_addr"]=> string(13) "192.168.222.1"

SELECT * FROM plugin_flowview_queries \G
*************************** 1. row ***************************
             id: 1
           name: prvni
      device_id: 0
    template_id: -1
        ex_addr: -1
       timespan: 0
      startdate: 2024-12-01 16:14
        enddate: 2024-12-01 20:14
      tosfields: 
       tcpflags: 
      protocols: 
       sourceip: 
     sourceport: 
sourceinterface: 
       sourceas: 
         destip: 
       destport: 
  destinterface: 
         destas: 
     statistics: 10
        printed: 0
      includeif: 2
      sortfield: src_addr
    cutofflines: 20
   cutoffoctets: 0
        resolve: N
     graph_type: bar
   graph_height: 300
    panel_table: on
    panel_bytes: 
  panel_packets: 
    panel_flows: 
