### PR TITLE
refactor: DRY flowview filters layout wrapper

### DIFF
--- a/flowview_filters.php
+++ b/flowview_filters.php
@@ -27,6 +27,7 @@ chdir('../../');
 include('./include/auth.php');
 include_once($config['base_path'] . '/plugins/flowview/setup.php');
 include_once($config['base_path'] . '/plugins/flowview/functions.php');
+include_once($config['base_path'] . '/plugins/flowview/ui_helpers.php');
 include_once($config['base_path'] . '/lib/time.php');
 include_once($config['base_path'] . '/lib/timespan_settings.php');
 
@@ -52,21 +53,11 @@ switch (get_request_var('action')) {
 		sort_filter();
 		break;
 	case 'edit':
-		if (!isset_request_var('embed')) {
-			top_header();
-		}
-
-		edit_filter();
-
-		if (!isset_request_var('embed')) {
-			bottom_footer();
-		}
+		flowview_filters_render_with_layout('edit_filter', true);
 
 		break;
 	default:
-		top_header();
-		show_filters();
-		bottom_footer();
+		flowview_filters_render_with_layout('show_filters');
 		break;
 }
 
@@ -399,4 +390,3 @@ function show_filters() {
 
 	form_end();
 }
-

--- a/tests/test_layout_wrapper.php
+++ b/tests/test_layout_wrapper.php
@@ -1,5 +1,16 @@
 <?php
 
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
+ +-------------------------------------------------------------------------+
+ */
+
 require_once __DIR__ . '/../ui_helpers.php';
 
 $events = [];
@@ -34,6 +45,13 @@ function assert_same($expected, $actual, $message) {
 	}
 }
 
+function assert_regex($pattern, $subject, $message) {
+	if (!preg_match($pattern, $subject)) {
+		fwrite(STDERR, $message . PHP_EOL);
+		exit(1);
+	}
+}
+
 flowview_filters_render_with_layout('test_renderer');
 assert_same(['top', 'render', 'bottom'], $events, 'Default wrapper should render with layout.');
 
@@ -52,14 +70,16 @@ if ($source === false) {
 	exit(1);
 }
 
-if (strpos($source, "flowview_filters_render_with_layout('edit_filter', true);") === false) {
-	fwrite(STDERR, 'Expected edit action to use shared layout helper.' . PHP_EOL);
-	exit(1);
-}
+assert_regex(
+	"/flowview_filters_render_with_layout\\(\\s*'edit_filter'\\s*,\\s*true\\s*\\)\\s*;/",
+	$source,
+	'Expected edit action to use shared layout helper.'
+);
 
-if (strpos($source, "flowview_filters_render_with_layout('show_filters');") === false) {
-	fwrite(STDERR, 'Expected default action to use shared layout helper.' . PHP_EOL);
-	exit(1);
-}
+assert_regex(
+	"/flowview_filters_render_with_layout\\(\\s*'show_filters'\\s*\\)\\s*;/",
+	$source,
+	'Expected default action to use shared layout helper.'
+);
 
 echo "OK\n";

--- a/tests/test_layout_wrapper.php
+++ b/tests/test_layout_wrapper.php
@@ -1,0 +1,65 @@
+<?php
+
+require_once __DIR__ . '/../ui_helpers.php';
+
+$events = [];
+$request_vars = [];
+
+function top_header() {
+	global $events;
+	$events[] = 'top';
+}
+
+function bottom_footer() {
+	global $events;
+	$events[] = 'bottom';
+}
+
+function isset_request_var($key) {
+	global $request_vars;
+	return isset($request_vars[$key]);
+}
+
+function test_renderer() {
+	global $events;
+	$events[] = 'render';
+}
+
+function assert_same($expected, $actual, $message) {
+	if ($expected !== $actual) {
+		fwrite(STDERR, $message . PHP_EOL);
+		fwrite(STDERR, 'Expected: ' . json_encode($expected) . PHP_EOL);
+		fwrite(STDERR, 'Actual:   ' . json_encode($actual) . PHP_EOL);
+		exit(1);
+	}
+}
+
+flowview_filters_render_with_layout('test_renderer');
+assert_same(['top', 'render', 'bottom'], $events, 'Default wrapper should render with layout.');
+
+$events = [];
+$request_vars['embed'] = 1;
+flowview_filters_render_with_layout('test_renderer', true);
+assert_same(['render'], $events, 'Embed-aware wrapper should skip layout when embed is set.');
+
+$events = [];
+flowview_filters_render_with_layout('test_renderer', false);
+assert_same(['top', 'render', 'bottom'], $events, 'Non-embed wrapper should keep layout even when embed is set.');
+
+$source = file_get_contents(__DIR__ . '/../flowview_filters.php');
+if ($source === false) {
+	fwrite(STDERR, 'Unable to read flowview_filters.php' . PHP_EOL);
+	exit(1);
+}
+
+if (strpos($source, "flowview_filters_render_with_layout('edit_filter', true);") === false) {
+	fwrite(STDERR, 'Expected edit action to use shared layout helper.' . PHP_EOL);
+	exit(1);
+}
+
+if (strpos($source, "flowview_filters_render_with_layout('show_filters');") === false) {
+	fwrite(STDERR, 'Expected default action to use shared layout helper.' . PHP_EOL);
+	exit(1);
+}
+
+echo "OK\n";

--- a/ui_helpers.php
+++ b/ui_helpers.php
@@ -7,18 +7,30 @@
  | modify it under the terms of the GNU General Public License             |
  | as published by the Free Software Foundation; either version 2          |
  | of the License, or (at your option) any later version.                  |
+ |                                                                         |
+ | This program is distributed in the hope that it will be useful,         |
+ | but WITHOUT ANY WARRANTY; without even the implied warranty of          |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the           |
+ | GNU General Public License for more details.                            |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDTool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+ | This code is designed, written, and maintained by the Cacti Group. See  |
+ | about.php and/or the AUTHORS file for specific developer information.   |
+ +-------------------------------------------------------------------------+
+ | http://www.cacti.net/                                                   |
  +-------------------------------------------------------------------------+
  */
 
 if (!function_exists('flowview_filters_render_with_layout')) {
-	function flowview_filters_render_with_layout($renderer, $respect_embed = false) {
+	function flowview_filters_render_with_layout(callable $renderer, $respect_embed = false) {
 		$should_wrap = (!$respect_embed || !isset_request_var('embed'));
 
 		if ($should_wrap) {
 			top_header();
 		}
 
-		call_user_func($renderer);
+		$renderer();
 
 		if ($should_wrap) {
 			bottom_footer();

--- a/ui_helpers.php
+++ b/ui_helpers.php
@@ -1,0 +1,27 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
+ +-------------------------------------------------------------------------+
+ */
+
+if (!function_exists('flowview_filters_render_with_layout')) {
+	function flowview_filters_render_with_layout($renderer, $respect_embed = false) {
+		$should_wrap = (!$respect_embed || !isset_request_var('embed'));
+
+		if ($should_wrap) {
+			top_header();
+		}
+
+		call_user_func($renderer);
+
+		if ($should_wrap) {
+			bottom_footer();
+		}
+	}
+}


### PR DESCRIPTION
## Summary
This PR implements issue #245 by removing repeated page layout wrapper logic from `flowview_filters.php`.

### Changes
- added `ui_helpers.php` with shared helper:
  - `flowview_filters_render_with_layout($renderer, $respect_embed = false)`
- updated `flowview_filters.php` action routing:
  - `edit` now calls `flowview_filters_render_with_layout('edit_filter', true)`
  - default path now calls `flowview_filters_render_with_layout('show_filters')`
- preserved existing embed behavior for edit rendering

## Validation
- `php -l flowview_filters.php`
- `php -l ui_helpers.php`
- `php -l tests/test_layout_wrapper.php`
- `php tests/test_layout_wrapper.php`

## Issue
Closes #245
