### PR TITLE
Update functions.php proxy config on dowload irr table

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -5773,7 +5773,7 @@ function flowview_check_databases($import_only = false, $force = false) {
 				$wget_proxy = '';
 				if (!file_exists($local_file)) {
 					if ($proxy != '') {
-						$wget_proxy = "-e use_proxy=on -e http_proxy=$proxy";
+						$wget_proxy = "-e use_proxy=on -e http_proxy=$proxy -e ftp_proxy=$proxy";
 				                if ($proxy_user != '') {
 							$wget_proxy .= " --proxy-user=$proxy_user --proxy-passwd=$proxy_password";
 						}


### PR DESCRIPTION
For wget to be able to go via a proxy for ftp file, it has to have the argument -e ftp_proxy. Defining just http_proxy is not enough.
So I propose to add ftp_proxy for the download in flowview_check_databases